### PR TITLE
Make FH objects public

### DIFF
--- a/FactoryHelper/Components/ConveyorMover.cs
+++ b/FactoryHelper/Components/ConveyorMover.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace FactoryHelper.Components
 {
     [Tracked]
-    class ConveyorMover : Component
+    public class ConveyorMover : Component
     {
         public Action<float> OnMove;
         public bool IsOnConveyor = false;

--- a/FactoryHelper/Components/FactoryActivator.cs
+++ b/FactoryHelper/Components/FactoryActivator.cs
@@ -5,7 +5,7 @@ using System;
 namespace FactoryHelper.Components
 {
     [Tracked]
-    class FactoryActivator : Component
+    public class FactoryActivator : Component
     {
         public bool Activated => ActivationCount > 0;
         public int ActivationCount { get; private set; } = 0;

--- a/FactoryHelper/Components/SteamCollider.cs
+++ b/FactoryHelper/Components/SteamCollider.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 namespace FactoryHelper.Components
 {
     [Tracked(false)]
-    class SteamCollider : Component
+    public class SteamCollider : Component
     {
         public Action<SteamWall> OnCollide;
         public Collider Collider;

--- a/FactoryHelper/Entities/BatteryBox.cs
+++ b/FactoryHelper/Entities/BatteryBox.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 namespace FactoryHelper.Entities
 {
     [CustomEntity("FactoryHelper/BatteryBox")]
-    class BatteryBox : Entity
+    public class BatteryBox : Entity
     {
         private readonly EntityID _id;
         private readonly Sprite _boxSprite;

--- a/FactoryHelper/Entities/BoomBox.cs
+++ b/FactoryHelper/Entities/BoomBox.cs
@@ -8,7 +8,7 @@ using Celeste.Mod.Entities;
 namespace FactoryHelper.Entities
 {
     [CustomEntity("FactoryHelper/BoomBox")]
-    class BoomBox : Solid
+    public class BoomBox : Solid
     {
         public ParticleType P_Steam = ParticleTypes.Steam;
         public ParticleType P_SteamAngry = new ParticleType(ParticleTypes.Steam)

--- a/FactoryHelper/Entities/Conveyor.cs
+++ b/FactoryHelper/Entities/Conveyor.cs
@@ -10,7 +10,7 @@ namespace FactoryHelper.Entities
 {
     [CustomEntity("FactoryHelper/Conveyor")]
     [Tracked]
-    class Conveyor : Solid
+    public class Conveyor : Solid
     {
         public const float ConveyorMoveSpeed = 40.0f;
 

--- a/FactoryHelper/Entities/DashFuseBox.cs
+++ b/FactoryHelper/Entities/DashFuseBox.cs
@@ -11,7 +11,7 @@ using FactoryHelper.Cutscenes;
 namespace FactoryHelper.Entities
 {
     [CustomEntity("FactoryHelper/DashFuseBox")]
-    class DashFuseBox : Solid
+    public class DashFuseBox : Solid
     {
         public enum Direction
         {

--- a/FactoryHelper/Entities/DashNegator.cs
+++ b/FactoryHelper/Entities/DashNegator.cs
@@ -8,7 +8,7 @@ using Celeste.Mod.Entities;
 namespace FactoryHelper.Entities
 {
     [CustomEntity("FactoryHelper/DashNegator")]
-    class DashNegator : Entity
+    public class DashNegator : Entity
     {
         public FactoryActivator Activator;
 

--- a/FactoryHelper/Entities/ElectrifiedWall.cs
+++ b/FactoryHelper/Entities/ElectrifiedWall.cs
@@ -14,7 +14,7 @@ namespace FactoryHelper.Entities
         "FactoryHelper/ElectrifiedWallDown = LoadDown",
         "FactoryHelper/ElectrifiedWallLeft = LoadLeft",
         "FactoryHelper/ElectrifiedWallRight = LoadRight")]
-    class ElectrifiedWall : FactorySpike
+    public class ElectrifiedWall : FactorySpike
     {
         public static Entity LoadUp(Level level, LevelData levelData, Vector2 offset, EntityData data) => new ElectrifiedWall(data, offset, Directions.Up);
         public static Entity LoadDown(Level level, LevelData levelData, Vector2 offset, EntityData data) => new ElectrifiedWall(data, offset, Directions.Down);

--- a/FactoryHelper/Entities/Fan.cs
+++ b/FactoryHelper/Entities/Fan.cs
@@ -11,7 +11,7 @@ namespace FactoryHelper.Entities
         "FactoryHelper/FanHorizontal = LoadHorizontal",
         "FactoryHelper/FanVertical = LoadVertical"
         )]
-    class Fan : Solid
+    public class Fan : Solid
     {
         public static Entity LoadHorizontal(Level level, LevelData levelData, Vector2 offset, EntityData data) => new Fan(data, offset, Directions.Horizontal);
         public static Entity LoadVertical(Level level, LevelData levelData, Vector2 offset, EntityData data) => new Fan(data, offset, Directions.Vertical);

--- a/FactoryHelper/Entities/MachineHeart.cs
+++ b/FactoryHelper/Entities/MachineHeart.cs
@@ -8,7 +8,7 @@ namespace FactoryHelper.Entities
 {
     [Tracked(false)]
     [CustomEntity("FactoryHelper/MachineHeart")]
-    class MachineHeart : Solid
+    public class MachineHeart : Solid
     {
         private Sprite _frontSprite;
         private Sprite _backSprite;

--- a/FactoryHelper/Entities/Piston.cs
+++ b/FactoryHelper/Entities/Piston.cs
@@ -12,7 +12,7 @@ namespace FactoryHelper.Entities
         "FactoryHelper/PistonDown = LoadDown",
         "FactoryHelper/PistonLeft = LoadLeft",
         "FactoryHelper/PistonRight = LoadRight")]
-    class Piston : Entity
+    public class Piston : Entity
     {
         public static Entity LoadUp(Level level, LevelData levelData, Vector2 offset, EntityData data) => new Piston(data, offset, Directions.Up);
         public static Entity LoadDown(Level level, LevelData levelData, Vector2 offset, EntityData data) => new Piston(data, offset, Directions.Down);

--- a/FactoryHelper/Entities/PowerLine.cs
+++ b/FactoryHelper/Entities/PowerLine.cs
@@ -10,7 +10,7 @@ namespace FactoryHelper.Entities
 {
     [CustomEntity("FactoryHelper/PowerLine")]
     [Tracked]
-    class PowerLine : Entity
+    public class PowerLine : Entity
     {
         public FactoryActivator Activator;
 

--- a/FactoryHelper/Entities/PressurePlate.cs
+++ b/FactoryHelper/Entities/PressurePlate.cs
@@ -8,7 +8,7 @@ using Celeste.Mod.Entities;
 namespace FactoryHelper.Entities
 {
     [CustomEntity("FactoryHelper/PressurePlate")]
-    class PressurePlate : Solid
+    public class PressurePlate : Solid
     {
         public Image CaseImage { get; private set; }
 

--- a/FactoryHelper/Entities/RustBerry.cs
+++ b/FactoryHelper/Entities/RustBerry.cs
@@ -8,7 +8,7 @@ using System.Collections;
 namespace FactoryHelper.Entities
 {
     [CustomEntity("FactoryHelper/RustBerry")]
-    class RustBerry : Entity
+    public class RustBerry : Entity
     {
         public static ParticleType P_Glow = new ParticleType(Strawberry.P_Glow) { Color = Calc.HexToColor("fc5a03"), Color2 = Calc.HexToColor("9e4210") };
         public static ParticleType P_GhostGlow = Strawberry.P_GhostGlow;

--- a/FactoryHelper/Entities/RustyLamp.cs
+++ b/FactoryHelper/Entities/RustyLamp.cs
@@ -9,7 +9,7 @@ namespace FactoryHelper.Entities
 {
     [Tracked(false)]
     [CustomEntity("FactoryHelper/RustyLamp")]
-    class RustyLamp : Entity
+    public class RustyLamp : Entity
     {
         public static readonly Color Color = Color.Lerp(Color.White, Color.Orange, 0.5f);
 

--- a/FactoryHelper/Entities/SteamWall.cs
+++ b/FactoryHelper/Entities/SteamWall.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 namespace FactoryHelper.Entities
 {
     [Tracked(false)]
-    class SteamWall : Entity
+    public class SteamWall : Entity
     {
         public static ParticleType P_FlyingDebris = new ParticleType
         {

--- a/FactoryHelper/Entities/ThrowBox.cs
+++ b/FactoryHelper/Entities/ThrowBox.cs
@@ -8,7 +8,7 @@ using System;
 namespace FactoryHelper.Entities
 {
     [CustomEntity("FactoryHelper/ThrowBox")]
-    class ThrowBox : Actor
+    public class ThrowBox : Actor
     {
         public Vector2 Speed;
         public Holdable Hold;

--- a/FactoryHelper/Entities/ThrowBoxSpawner.cs
+++ b/FactoryHelper/Entities/ThrowBoxSpawner.cs
@@ -10,7 +10,7 @@ using FactoryHelper.Components;
 namespace FactoryHelper.Entities
 {
     [CustomEntity("FactoryHelper/ThrowBoxSpawner")]
-    class ThrowBoxSpawner : Entity
+    public class ThrowBoxSpawner : Entity
     {
         public FactoryActivator Activator;
 

--- a/FactoryHelper/Entities/WindTunnel.cs
+++ b/FactoryHelper/Entities/WindTunnel.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 namespace FactoryHelper.Entities
 {
     [CustomEntity("FactoryHelper/WindTunnel")]
-    class WindTunnel : Entity
+    public class WindTunnel : Entity
     {
         public FactoryActivator Activator { get; }
 

--- a/FactoryHelper/ScreenWipes/GearWipe.cs
+++ b/FactoryHelper/ScreenWipes/GearWipe.cs
@@ -6,7 +6,7 @@ using Microsoft.Xna.Framework;
 
 namespace FactoryHelper.ScreenWipes
 {
-    class GearWipe : ScreenWipe
+    public class GearWipe : ScreenWipe
     {
         private struct Gear
         {

--- a/FactoryHelper/Triggers/FactoryActivationTrigger.cs
+++ b/FactoryHelper/Triggers/FactoryActivationTrigger.cs
@@ -8,7 +8,7 @@ using Celeste.Mod.Entities;
 namespace FactoryHelper.Triggers
 {
     [CustomEntity("FactoryHelper/FactoryActivationTrigger")]
-    class FactoryActivationTrigger : Trigger
+    public class FactoryActivationTrigger : Trigger
     {
         public FactoryActivator Activator { get; }
 

--- a/FactoryHelper/Triggers/FactoryEventTrigger.cs
+++ b/FactoryHelper/Triggers/FactoryEventTrigger.cs
@@ -8,7 +8,7 @@ using Monocle;
 namespace FactoryHelper.Triggers
 {
     [CustomEntity("FactoryHelper/EventTrigger")]
-    class FactoryEventTrigger : Trigger
+    public class FactoryEventTrigger : Trigger
     {
         private readonly string _eventName;
 

--- a/FactoryHelper/Triggers/PremanentActivationTrigger.cs
+++ b/FactoryHelper/Triggers/PremanentActivationTrigger.cs
@@ -8,7 +8,7 @@ using FactoryHelper.Components;
 namespace FactoryHelper.Triggers
 {
     [CustomEntity("FactoryHelper/PermanentActivationTrigger")]
-    class PremanentActivationTrigger : Trigger
+    public class PremanentActivationTrigger : Trigger
     {
         private readonly FactoryActivator[] _activators;
         private readonly HashSet<string> _shouldStayPermanent = new HashSet<string>();

--- a/FactoryHelper/Triggers/SpawnSteamWallTrigger.cs
+++ b/FactoryHelper/Triggers/SpawnSteamWallTrigger.cs
@@ -8,7 +8,7 @@ using Monocle;
 namespace FactoryHelper.Triggers
 {
     [CustomEntity("FactoryHelper/SpawnSteamWallTrigger")]
-    class SpawnSteamWallTrigger : Trigger
+    public class SpawnSteamWallTrigger : Trigger
     {
         private bool _spawned = false;
 

--- a/FactoryHelper/Triggers/SpecialBoxDeactivationTrigger.cs
+++ b/FactoryHelper/Triggers/SpecialBoxDeactivationTrigger.cs
@@ -7,7 +7,7 @@ using Monocle;
 namespace FactoryHelper.Triggers
 {
     [CustomEntity("FactoryHelper/SpecialBoxDeactivationTrigger")]
-    class SpecialBoxDeactivationTrigger : Trigger
+    public class SpecialBoxDeactivationTrigger : Trigger
     {
         public SpecialBoxDeactivationTrigger(EntityData data, Vector2 offset) : base(data, offset)
         {

--- a/FactoryHelper/Triggers/SteamWallColorTrigger.cs
+++ b/FactoryHelper/Triggers/SteamWallColorTrigger.cs
@@ -8,7 +8,7 @@ using Monocle;
 namespace FactoryHelper.Triggers
 {
     [CustomEntity("FactoryHelper/SteamWallColorTrigger")]
-    class SteamWallColorTrigger : Trigger
+    public class SteamWallColorTrigger : Trigger
     {
         private Color overrideColor = Color.White;
         public float duration;

--- a/FactoryHelper/Triggers/SteamWallSpeedTrigger.cs
+++ b/FactoryHelper/Triggers/SteamWallSpeedTrigger.cs
@@ -7,7 +7,7 @@ using Monocle;
 namespace FactoryHelper.Triggers
 {
     [CustomEntity("FactoryHelper/SteamWallSpeedTrigger")]
-    class SteamWallSpeedTrigger : Trigger
+    public class SteamWallSpeedTrigger : Trigger
     {
         private float speed = 1f;
         public SteamWallSpeedTrigger(EntityData data, Vector2 offset) : base(data, offset)


### PR DESCRIPTION
Entities/etc need to be public to be accessible from other assemblies without reflection (even with reflection some things are still difficult or impossible) for derived classes, hooks, etc.

The current accessibility choices seem pretty arbitrary anyway, would be nice to make them consistent