### PR TITLE
(Piston.cs) fix lift speed with changing delta time

### DIFF
--- a/FactoryHelper/Entities/Piston.cs
+++ b/FactoryHelper/Entities/Piston.cs
@@ -563,7 +563,10 @@ namespace FactoryHelper.Entities
                         if (player != null)
                         {
                             float newY = _base.Y + _grabPositionModifier + (player.Y - (_base.Y + _grabPositionModifier)) * heightAfter / heightBefore;
-                            player.LiftSpeed = new Vector2(player.LiftSpeed.X, (newY - player.Y) * Engine.DeltaTime);
+                            if (Engine.DeltaTime != 0f)
+                            {
+                                player.LiftSpeed = new Vector2(player.LiftSpeed.X, (newY - player.Y) / Engine.DeltaTime);
+                            }
                             player.MoveV(newY - player.Y);
                         }
                     }
@@ -588,7 +591,10 @@ namespace FactoryHelper.Entities
                         if (player != null)
                         {
                             float newX = _base.X + _grabPositionModifier + (player.X - (_base.X + _grabPositionModifier)) * widthAfter / widthBefore;
-                            player.LiftSpeed = new Vector2((newX - player.X) * Engine.DeltaTime, player.LiftSpeed.Y);
+                            if (Engine.DeltaTime != 0f)
+                            {
+                                player.LiftSpeed = new Vector2((newX - player.X) / Engine.DeltaTime, player.LiftSpeed.Y);
+                            }
                             player.MoveH(newX - player.X);
                         }
                     }

--- a/FactoryHelper/Entities/Piston.cs
+++ b/FactoryHelper/Entities/Piston.cs
@@ -563,7 +563,7 @@ namespace FactoryHelper.Entities
                         if (player != null)
                         {
                             float newY = _base.Y + _grabPositionModifier + (player.Y - (_base.Y + _grabPositionModifier)) * heightAfter / heightBefore;
-                            player.LiftSpeed = new Vector2(player.LiftSpeed.X, (newY - player.Y) / Engine.DeltaTime);
+                            player.LiftSpeed = new Vector2(player.LiftSpeed.X, (newY - player.Y) * Engine.DeltaTime);
                             player.MoveV(newY - player.Y);
                         }
                     }
@@ -588,7 +588,7 @@ namespace FactoryHelper.Entities
                         if (player != null)
                         {
                             float newX = _base.X + _grabPositionModifier + (player.X - (_base.X + _grabPositionModifier)) * widthAfter / widthBefore;
-                            player.LiftSpeed = new Vector2((newX - player.X) / Engine.DeltaTime, player.LiftSpeed.Y);
+                            player.LiftSpeed = new Vector2((newX - player.X) * Engine.DeltaTime, player.LiftSpeed.Y);
                             player.MoveH(newX - player.X);
                         }
                     }


### PR DESCRIPTION
In the pistons, Engine Delta time was incorrectly divided, rather than multiplied. This caused the lift speed given to be inaccurate, and caused crashes when combined with CrystallineHelper time stop. Changing it to `*` operator fixes the behavior to work as intended, and prevents crashing.